### PR TITLE
Check if a schema resouce has a title

### DIFF
--- a/lib/jdoc/resource.rb
+++ b/lib/jdoc/resource.rb
@@ -2,8 +2,15 @@ module Jdoc
   class Resource
     attr_reader :schema
 
+    class TitleNotFound < StandardError
+    end
+
     # @param schema [JsonSchema::Schema]
     def initialize(schema)
+      if schema.title.nil?
+        raise TitleNotFound
+      end
+
       @schema = schema
     end
 

--- a/spec/fixtures/schema-without-title.yml
+++ b/spec/fixtures/schema-without-title.yml
@@ -1,0 +1,4 @@
+---
+"$schema": http://json-schema.org/draft-04/hyper-schema
+properties:
+  app: {}

--- a/spec/jdoc/generator_spec.rb
+++ b/spec/jdoc/generator_spec.rb
@@ -19,5 +19,15 @@ describe Jdoc::Generator do
     it "returns a String of API documentation in Markdown from given JSON Schema" do
       should == File.read(File.expand_path("../../../example-api-documentation.md", __FILE__))
     end
+
+    context "schema without title" do
+      let(:schema_path) do
+        File.expand_path("../../fixtures/schema-without-title.yml", __FILE__)
+      end
+
+      it "raises TitleNotFound" do
+        expect { subject }.to raise_error Jdoc::Resource::TitleNotFound
+      end
+    end
   end
 end


### PR DESCRIPTION
Jdoc::Resource depends strongly on its `title`, and if it has no title Jdoc::Generator raises the following errors:

```
NoMethodError: undefined method `gsub' for nil:NilClass

/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/jdoc-0.1.2/lib/jdoc/resource.rb:21:in `anchor'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/jdoc-0.1.2/lib/jdoc/resource.rb:28:in `hyperlink'
(erubis:3:in `block in result'
(erubis:2:in `each'
(erubis:2:in `result'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:65:in `eval'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:65:in `result'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/jdoc-0.1.2/lib/jdoc/generator.rb:19:in `call'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/jdoc-0.1.2/lib/jdoc/generator.rb:8:in `call'
/Users/gfx/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rack-json_schema-1.0.6/lib/rack/json_schema/docs.rb:13:in `initialize'
```

which is hard to debug.

This patch checks titles to make debugging easier.
