### PR TITLE
Add support for multipart/form-data request

### DIFF
--- a/example-api-documentation.md
+++ b/example-api-documentation.md
@@ -7,6 +7,7 @@ A schema for a small example API.
  * [GET /apps/:id](#get-appsid)
  * [GET /apps](#get-apps)
  * [PATCH /apps/:id](#patch-appsid)
+ * [POST /apps/:id/files](#post-appsidfiles)
 * [Recipe](#recipe)
  * [GET /recipes](#get-recipes)
 * [User](#user)
@@ -173,6 +174,41 @@ Host: api.example.com
 
 ```
 HTTP/1.1 200
+Content-Type: application/json
+
+{
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "name": "example",
+  "private": false,
+  "deleted_at": null,
+  "user_ids": [
+    1
+  ],
+  "users": [
+    {
+      "name": "alice"
+    }
+  ]
+}
+```
+
+### POST /apps/:id/files
+Upload an attachment file for an app
+
+```
+POST /apps/:id/files HTTP/1.1
+Content-Type: multipart/form-data; boundary=---BoundaryX
+Host: api.example.com
+
+-----BoundaryX
+Content-Disposition: form-data; name="[file]"
+
+... contents of file ...
+-----BoundaryX--
+```
+
+```
+HTTP/1.1 201
 Content-Type: application/json
 
 {

--- a/jdoc.gemspec
+++ b/jdoc.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "erubis"
   spec.add_dependency "json_schema"
+  spec.add_dependency "rack"
   spec.add_dependency "redcarpet"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "pry"

--- a/lib/jdoc.rb
+++ b/lib/jdoc.rb
@@ -4,10 +4,12 @@ require "cgi"
 require "erubis"
 require "json_schema"
 require "redcarpet"
+require "rack"
 require "uri"
 
 require "jdoc/generator"
 require "jdoc/link"
+require 'jdoc/request/multipart'
 require "jdoc/property"
 require "jdoc/resource"
 require "jdoc/schema"

--- a/lib/jdoc/request/multipart.rb
+++ b/lib/jdoc/request/multipart.rb
@@ -1,0 +1,43 @@
+module Jdoc
+  module Request
+    class Multipart
+      MULTIPART_BOUNDARY = "---BoundaryX"
+
+      # @return [String] returns boundary parameter for multipart content-type
+      def self.boundary
+        "boundary=#{MULTIPART_BOUNDARY}"
+      end
+
+      # @param params [Hash] request parameters
+      def initialize(params)
+        @params = params
+      end
+
+      # @return [String] request body of multipart/form-data request.
+      # @example
+      #   -----BoundaryX
+      #   Content-Disposition: form-data; name="file"
+      #
+      #   ... contents of file ...
+      #   -----BoundaryX--
+      def dump
+        contents = Rack::Multipart::Generator.new(@params, false).dump.map do |name, content|
+          content_part(content, name)
+        end.join
+        "#{contents}\r--#{MULTIPART_BOUNDARY}--\r"
+      end
+
+      private
+
+      # return [String] content part of multipart/form-data request
+      def content_part(content, name)
+<<-EOF
+--#{MULTIPART_BOUNDARY}\r
+Content-Disposition: form-data; name="#{name}"\r
+\r
+#{content}
+EOF
+      end
+    end
+  end
+end

--- a/spec/fixtures/schema.yml
+++ b/spec/fixtures/schema.yml
@@ -40,6 +40,11 @@ definitions:
         items:
           type: integer
           example: 1
+      file:
+        description: an attachment of app
+        example: '... contents of file ...'
+        readOnly: false
+        type: string
     links:
     - description: Create a new app.
       href: "/apps"
@@ -78,6 +83,18 @@ definitions:
         type:
         - object
       title: Update
+    - description: Upload an attachment file for an app
+      href: "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fid)}/files"
+      method: POST
+      rel: create
+      encType: multipart/form-data
+      schema:
+        properties:
+          file:
+            "$ref": "#/definitions/app/definitions/file"
+        type:
+        - object
+      title: Create
     properties:
       id:
         "$ref": "#/definitions/app/definitions/id"

--- a/template.md.erb
+++ b/template.md.erb
@@ -28,7 +28,7 @@
 
 ```
 <%= link.method %> <%= link.path %><%= link.query_string %> HTTP/1.1
-<%= "Content-Type: application/json\n" if link.has_request_body? -%>
+<%= "Content-Type: #{link.content_type}\n" if link.has_request_body? -%>
 Host: <%= schema.host_with_port %>
 <%= "\n" + link.request_body if link.has_request_body? -%>
 ```


### PR DESCRIPTION
With this PR, jdoc can display `Content-Type` and body of a request when `link.encType` is specified as `multipart/form-data`.

The dump of a request body is performed by `Rack`. 

If there is a nested field name in definition of link schema, such as 

``` yaml
schema:
  properties:
    key1:
      key2:
        "$ref": "file"
```

, then  it will be displayed as `[key1][key2]`, using Rack (and Rails) convention.
