### PR TITLE
Show reason phrase in response example

### DIFF
--- a/example-api-documentation.md
+++ b/example-api-documentation.md
@@ -60,8 +60,9 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 201
+HTTP/1.1 201 Created
 Content-Type: application/json
+
 {
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "name": "example",
@@ -87,7 +88,7 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 204
+HTTP/1.1 204 No Content
 ```
 
 ### GET /apps/:id
@@ -99,8 +100,9 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 200
+HTTP/1.1 200 OK
 Content-Type: application/json
+
 {
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "name": "example",
@@ -126,8 +128,9 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 200
+HTTP/1.1 200 OK
 Content-Type: application/json
+
 [
   {
     "id": "01234567-89ab-cdef-0123-456789abcdef",
@@ -166,8 +169,9 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 200
+HTTP/1.1 200 OK
 Content-Type: application/json
+
 {
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "name": "example",
@@ -205,8 +209,9 @@ Content-Disposition: form-data; name="[file]"
 ```
 
 ```
-HTTP/1.1 201
+HTTP/1.1 201 Created
 Content-Type: application/json
+
 {
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "name": "example",
@@ -241,8 +246,9 @@ Host: api.example.com
 ```
 
 ```
-HTTP/1.1 200
+HTTP/1.1 200 OK
 Content-Type: application/json
+
 [
   {
     "name": "Sushi",

--- a/lib/jdoc/link.rb
+++ b/lib/jdoc/link.rb
@@ -172,6 +172,18 @@ module Jdoc
       end
     end
 
+    # @return [String] Preferred respone reason phrase for this endpoint
+    def response_reason_phrase
+      case
+      when method == "POST"
+        "Created"
+      when has_response_body?
+        "OK"
+      else
+        "No Content"
+      end
+    end
+
     # @return [JsonSchema::Schema] Response schema for this link
     def response_schema
       @raw_link.target_schema || @raw_link.parent

--- a/template.md.erb
+++ b/template.md.erb
@@ -46,9 +46,9 @@ Host: <%= schema.host_with_port %>
 ```
 
 ```
-HTTP/1.1 <%= link.response_status %>
+HTTP/1.1 <%= link.response_status %> <%= link.response_reason_phrase %>
 <%= "Content-Type: application/json" if link.has_response_body? -%>
-<%= "\n#{link.response_body}\n" if link.has_response_body? -%>
+<%= "\n\n#{link.response_body}\n" if link.has_response_body? -%>
 ```
 
 <% end %>


### PR DESCRIPTION
With this PR, the response example will be highlighted with `http` syntax highlighter in Qiita.

Without the reason phase, `http` syntax highlighter fails highlighting.
![2015-02-24 14 58 06](https://cloud.githubusercontent.com/assets/514164/6344027/8f64458a-bc35-11e4-8b51-74471401b89c.png)

But with the reason phase and a line break before the response body, it will be highlighted.
![2015-02-24 15 01 06](https://cloud.githubusercontent.com/assets/514164/6344048/fc275b6c-bc35-11e4-94f5-807e88af0701.png)
