### PR TITLE
Add Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         ruby:
           - '3.3'
+          - '3.4'
+          - '4.0'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     jdoc (0.4.4)
       activesupport
-      erubis
+      erubi
       json_schema
       rack
       redcarpet
@@ -11,17 +11,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
+    activesupport (7.1.6)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
       mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     base64 (0.2.0)
+    benchmark (0.5.0)
     bigdecimal (3.1.5)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -29,13 +33,17 @@ GEM
     diff-lcs (1.5.0)
     drb (2.2.0)
       ruby2_keywords
-    erubis (2.7.0)
+    erubi (1.13.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json_schema (0.21.0)
+    logger (1.7.0)
     method_source (1.0.0)
-    minitest (5.21.1)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
     mutex_m (0.2.0)
+    prism (1.9.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -56,6 +64,7 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rack (3.0.8)
-    rake (13.1.0)
+    rake (13.4.2)
     redcarpet (3.6.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -76,7 +76,7 @@ DEPENDENCIES
   bundler (>= 1.6)
   jdoc!
   pry
-  rake
+  rake (>= 13.2.0)
   rspec (>= 2.14.1)
 
 BUNDLED WITH

--- a/jdoc.gemspec
+++ b/jdoc.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "erubis"
+  spec.add_dependency "erubi"
   spec.add_dependency "json_schema"
   spec.add_dependency "rack"
   spec.add_dependency "redcarpet"

--- a/jdoc.gemspec
+++ b/jdoc.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "redcarpet"
   spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 13.2.0"
   spec.add_development_dependency "rspec", ">= 2.14.1"
 end

--- a/lib/jdoc.rb
+++ b/lib/jdoc.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/object/to_query"
 require "active_support/core_ext/string/inflections"
 require "cgi"
-require "erubis"
+require "erubi"
 require "json_schema"
 require "redcarpet"
 require "rack"

--- a/lib/jdoc/generator.rb
+++ b/lib/jdoc/generator.rb
@@ -24,10 +24,10 @@ module Jdoc
     # @note Add some fix to adapt to GitHub anchor style
     # @return [String] Generated text
     def call
-      markdown = markdown_renderer.result(schema: schema)
+      markdown = render_erb(markdown_template, schema: schema)
       if @html
         html = markdown_parser.render(markdown)
-        html =  html_renderer.result(body: html)
+        html = render_erb(html_template, body: html)
         html.gsub(/id="(.+)"/) {|text| text.tr("/:", "") }
       else
         markdown
@@ -38,9 +38,11 @@ module Jdoc
 
     private
 
-    # @return [Erubis::Eruby] Renderer to render HTML that takes HTML string
-    def html_renderer
-      Erubis::Eruby.new(html_template)
+    # @return [String]
+    def render_erb(template, **variables)
+      b = binding
+      variables.each { |k, v| b.local_variable_set(k, v) }
+      eval(Erubi::Engine.new(template).src, b)
     end
 
     # @returns [String] Path to ERB template to render HTML
@@ -64,11 +66,6 @@ module Jdoc
         fenced_code_blocks: true,
         no_intra_emphasis: true,
       )
-    end
-
-    # @return [Erubis::Eruby] Renderer to render Markdown that takes schema data
-    def markdown_renderer
-      Erubis::Eruby.new(markdown_template)
     end
 
     # @return [String] Content of specified Markdown template


### PR DESCRIPTION
## What
- Support Ruby 4.0

## How
- Replace `erubis` gem with `erubi` gem
  - Change `Erubis::Eruby#result` to `Erubi::Engine` based implementation
- Bump minimum `rake` version to >= 13.2.0
- Add Ruby 3.4 and 4.0 to CI test matrix

## Why
- `erubis` is unmaintained and incompatible with Ruby 4.0
- `rake` 13.1.0 depends on `ostruct`, which was removed from default gems in Ruby 4.0